### PR TITLE
Show missing clases in all floors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run the command `/ct import sbd` ingame. Requires ChatTriggers to be installed.
 <details>
 <summary>Show Missing Classes</summary>
     
-* shows missing classes in M4/M6/M7 party finder
+* shows missing classes in party finder
 </details>
 
 ## Commands

--- a/features/partyfinder.js
+++ b/features/partyfinder.js
@@ -18,7 +18,7 @@ const registerPartyFinderTriggers = () => {
         const dungeonType = getDungeonType(lore)
         let hasChanged = false
 
-        if(Config.missingclasses && dungeonType == "master_catacombs" && [4, 6, 7].includes(floor) && !hasMissingClasses(lore)) {
+        if(Config.missingclasses && !hasMissingClasses(lore)) {
             const missingClasses = getMissingClasses(lore)
             lore.push(`§e§lMissing:§r§f ${missingClasses.join(", ")}`)
             item.setLore(lore)

--- a/features/partyfinder.js
+++ b/features/partyfinder.js
@@ -18,7 +18,7 @@ const registerPartyFinderTriggers = () => {
         const dungeonType = getDungeonType(lore)
         let hasChanged = false
 
-        if(Config.missingclasses && !hasMissingClasses(lore)) {
+        if(Config.missingclasses && [1, 2, 3, 4, 5, 6, 7].includes(floor) && !hasMissingClasses(lore)) {
             const missingClasses = getMissingClasses(lore)
             lore.push(`§e§lMissing:§r§f ${missingClasses.join(", ")}`)
             item.setLore(lore)


### PR DESCRIPTION
I would like to see missing classes in every floor and I don't really see a reason to limit it to m4/m6/m7 since this information is also useful in other floors.