### PR TITLE
Fix dungeon stats fallback

### DIFF
--- a/features/autokick.js
+++ b/features/autokick.js
@@ -87,7 +87,7 @@ const getRawPB = (selectedfloor, player) => {
 }
 
 const getRequiredPB = () => {
-    requiredPB = Config.requiredPB
+    const requiredPB = Config.requiredPB
     if(requiredPB == parseInt(requiredPB)) {
         return parseInt(requiredPB) * 1000
     }
@@ -100,7 +100,7 @@ const getRequiredPB = () => {
 }
 
 const getRequiredSecrets = () => {
-    requiredSecrets = Config.requiredSecrets
+    const requiredSecrets = Config.requiredSecrets
     if(requiredSecrets == parseInt(requiredSecrets)) {
         return parseInt(requiredSecrets)
     }

--- a/util/apis/stats/skycrypt.js
+++ b/util/apis/stats/skycrypt.js
@@ -1,6 +1,6 @@
 import { timeToString } from "../../calc.js"
 
-const urlFunc = (uuid) => `https://sky.shiiyu.moe/api/v2/dungeons/${uuid}`
+const urlFunc = (uuid) => `https://sky.shiiiyu.moe/api/v2/dungeons/${uuid}`
 
 const transformFunc = (data) => {
     const profiles = Object.values(data.profiles)
@@ -22,7 +22,7 @@ const transformFunc = (data) => {
     for(let i = 1; i <= 7; i++) {
         const dungeonTypes = ["catacombs", "master_catacombs"]
         dungeonTypes.forEach(type => {
-            obj.dungeons.pb[type][i] = this.getFloorPB(profile, type, i)
+            obj.dungeons.pb[type][i] = getFloorPB(profile, type, i)
         })
     }
 

--- a/util/calc.js
+++ b/util/calc.js
@@ -2,8 +2,8 @@ const timeToString = (timeMilliseconds) => {
     if(!timeMilliseconds) {
         return "No S+"
     }
-    timeSeconds = Math.floor(timeMilliseconds / 1000)
-    timeMinutes = Math.floor(timeSeconds / 60)
+    const timeSeconds = Math.floor(timeMilliseconds / 1000)
+    const timeMinutes = Math.floor(timeSeconds / 60)
     return `${timeMinutes}:${(timeSeconds % 60).toString().padStart(2, "0")}`
 }
 


### PR DESCRIPTION
Fixes a dungeon stats fallback and a couple of small runtime footguns.

- call the local PB helper directly when transforming stats data
- declare temporary values in time and autokick parsing helpers